### PR TITLE
Switch download URL to archive.org version

### DIFF
--- a/html-help-workshop/tools/chocolateyinstall.ps1
+++ b/html-help-workshop/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop';
 
 $packageName = 'html-help-workshop'
-$url = 'https://download.microsoft.com/download/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe'
+$url = 'https://web.archive.org/web/20200918004813/https://download.microsoft.com/download/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe'
 $checksum = '53899be5da83419d772d5b97e653da7c'
 
 # a temporary directory for extracted installer files


### PR DESCRIPTION
The original download URL seems to have been removed by Microsoft but the file has been stored by the archive.org web-crawler.

I imagine there is no legal issue on your part for switching to this URL, since you are not hosting the cached copy, but possibly this is something you might want to check with some authority at Chocolatey.